### PR TITLE
Updated the bootstrap-sass gem to 3.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bootstrap-sass (2.3.2.2)
+      sass (~> 3.2)
     json (1.5.1)
     mini_portile (0.6.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     pdftohtmlr (0.4.2)
       nokogiri (>= 1.3.3)
+    sass (3.4.10)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass (~> 2.0)
   json (= 1.5.1)
   pdftohtmlr (= 0.4.2)


### PR DESCRIPTION
bootstrap-sass has been successfully updated from version 2.3.2.2 to version 3.3.3.
